### PR TITLE
avoid linking packages with the same name locally and in npm's repository

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ function zelda (rootPath, opts) {
 
   // get packages in code folder
   var codePkgs = getCodePkgs(codePath)
-
   if (opts.install) npmInstall(rootPath)
 
   var pkgsToPurge = {}
@@ -63,9 +62,16 @@ function zelda (rootPath, opts) {
 
     var pkgPath = path.join(codePath, pkgToPurge)
     traverseNodeModules(pkgPath, function (pkgName, pkgPath) {
-      if (pkgsToPurge[pkgName]) rmDir(pkgPath)
+      if (pkgsToPurge[pkgName] && referencesGitHub(pkgName, pkgPath)) {
+        rmDir(pkgPath)
+      }
     })
   })
+
+  function referencesGitHub(name, pkgPath) {
+    const pkgJson = require(`${path.resolve(pkgPath, '../../')}/package.json`);
+    return pkgJson.dependencies[name] && pkgJson.dependencies[name].includes('github.com');
+  }
 
   function rmDir (dirPath) {
     console.log('[zelda] rm -rf ' + dirPath)


### PR DESCRIPTION
This is aimed to avoid linking packages with the same name on the filesystem and on npm. It will check the package.json of the repository that it's traversing and will verify it's pointing to 'github.com' before "linking it" (not actual link but a tricky solution using Node's resolution algorithm for modules).